### PR TITLE
feat(multiples): add size variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .nyc_output
 node_modules/
-dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .nyc_output
 node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ multiple({
 
 multiple({
   selections: [
+    { stake: 10, odds: { decimal: 10 }, terms: '1/4' },
+    { stake: 10, odds: { decimal: 10 }, terms: '1/4' },
+    { stake: 10, odds: { decimal: 5 }, terms: '1/4' }
+  ],
+  stake: 10,
+  size: 2
+});
+// $> 2000
+
+multiple({
+  selections: [
     { stake: 10, odds: { decimal: 5 }, terms: '1/4' },
     { stake: 10, odds: { decimal: 5 }, terms: '1/4' },
     { stake: 10, odds: { decimal: 5 }, terms: '1/4' }

--- a/lib/main.js
+++ b/lib/main.js
@@ -44,8 +44,8 @@ function accumulator({
   return calculateAccumulator(selections, stake, ew, idx, place);
 }
 
-function calculateMultiple(selections, stake, ew = false, fullCover = false) {
-  const count = selections.length;
+function calculateMultiple(selections, stake, ew = false, fullCover = false, size = null) {
+  const count = size || selections.length;
   const start = fullCover ? 1 : 2;
   let allCombos = [];
 
@@ -60,9 +60,9 @@ function calculateMultiple(selections, stake, ew = false, fullCover = false) {
 }
 
 function multiple({
-  selections, stake, ew, fullCover
+  selections, stake, ew, fullCover, size
 }) {
-  return calculateMultiple(selections, stake, ew, fullCover);
+  return calculateMultiple(selections, stake, ew, fullCover, size);
 }
 
 function effectiveOdds(selections) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -46,7 +46,10 @@ function accumulator({
 
 function calculateMultiple(
   selections,
-  stake, ew = false, fullCover = false, count = selections.length
+  stake,
+  ew = false,
+  fullCover = false,
+  count = selections.length
 ) {
   const start = fullCover ? 1 : 2;
   let allCombos = [];

--- a/lib/main.js
+++ b/lib/main.js
@@ -44,8 +44,10 @@ function accumulator({
   return calculateAccumulator(selections, stake, ew, idx, place);
 }
 
-function calculateMultiple(selections, stake, ew = false, fullCover = false, size = null) {
-  const count = size || selections.length;
+function calculateMultiple(
+  selections,
+  stake, ew = false, fullCover = false, count = selections.length
+) {
   const start = fullCover ? 1 : 2;
   let allCombos = [];
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -44,13 +44,8 @@ function accumulator({
   return calculateAccumulator(selections, stake, ew, idx, place);
 }
 
-function calculateMultiple(
-  selections,
-  stake,
-  ew = false,
-  fullCover = false,
-  count = selections.length
-) {
+function calculateMultiple(selections, stake, opts) {
+  const { ew, fullCover, count } = opts;
   const start = fullCover ? 1 : 2;
   let allCombos = [];
 
@@ -67,7 +62,9 @@ function calculateMultiple(
 function multiple({
   selections, stake, ew, fullCover, size
 }) {
-  return calculateMultiple(selections, stake, ew, fullCover, size);
+  const count = size || selections.length;
+  const opts = { ew, fullCover, count };
+  return calculateMultiple(selections, stake, opts);
 }
 
 function effectiveOdds(selections) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bet-return-js",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4331,6 +4331,15 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -4350,15 +4359,6 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.10.0",
         "function-bind": "1.1.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/test/main.js
+++ b/test/main.js
@@ -287,6 +287,25 @@ test('full cover ew multiple with fractional odds three selections', (t) => {
   t.equal(result, expected);
 });
 
+test('multiple doubles with three selections', (t) => {
+  const params = {
+    selections: [
+      { stake: 10, odds: { decimal: 10 }, terms: '1/4' },
+      { stake: 10, odds: { decimal: 10 }, terms: '1/4' },
+      { stake: 10, odds: { decimal: 5 }, terms: '1/4' }
+    ],
+    stake: 10,
+    size: 2
+  };
+
+  t.plan(1);
+
+  const result = multiple(params);
+  const expected = 2000;
+
+  t.equal(result, expected);
+});
+
 test('ew and fullCover default to false', (t) => {
   const params = {
     selections: [


### PR DESCRIPTION
In order to be able to calculate estimated returns for multiples such as doubles when we have 3 selections, needed to add a size variable to the `multiple` function.

The size defaults to the selections length.